### PR TITLE
Bump ruby -v to 3.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:2.7.5-node
+FROM cimg/ruby:3.1.0-node
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
   postgresql-client \


### PR DESCRIPTION
Have to discuss order of operations first, but necessary to bump the ruby version in main repo.