### PR TITLE
Bump main to 2.7.6 after upgrading occupier/occupier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:2.7.5-node
+FROM cimg/ruby:2.7.6-node
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
   postgresql-client \


### PR DESCRIPTION
### Summary
- occupier/occupier is already referencing 2.7.6 via the `next` build
- switch the main build to 2.7.6, then will update occupier/occupier to stop referencing `next`