### PR TITLE
Ruby 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:3.1.3-node
+FROM cimg/ruby:3.2.1-node
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
   postgresql-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:3.2.1-node
+FROM cimg/ruby:3.2.2-node
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
   postgresql-client \


### PR DESCRIPTION
[occupier/occupier@main](https://github.com/occupier/occupier/blob/main/.circleci/config.yml#L19) is already on `next`, so there's no harm in merging this now.